### PR TITLE
Fix README placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,44 +5,44 @@
 
 ## 🔗 Live Example
 
-[https://<your-username>.github.io/<repo-name>](https://<your-username>.github.io/<repo-name>)
+[https://\<your-username\>.github.io/\<repo-name\>](https://<your-username>.github.io/<repo-name>)
 
 ## 🎨 Usage
 
 ### Default view
 
-https://<your-site>.github.io/
+`https://<your-site>.github.io/`
 
 ### Themed view
 
-https://<your-site>.github.io/?fancy=sunset
+`https://<your-site>.github.io/?fancy=sunset`
 
 ### Custom background and text colors
 
-https://<your-site>.github.io/?bg=black\&fg=white
+`https://<your-site>.github.io/?bg=black\&fg=white`
 
 ### Image/GIF background
 
-https://<your-site>.github.io/?img=https://example.com/wave.gif
+`https://<your-site>.github.io/?img=https://example.com/wave.gif`
 
 ### Add links
 
-https://<your-site>.github.io/?links=Firepoker|https%3A%2F%2Ffirepoker.app%2F%23%2Fgames%2Fnew
+`https://<your-site>.github.io/?links=Firepoker|https%3A%2F%2Ffirepoker.app%2F%23%2Fgames%2Fnew`
 
 ### Custom sprint length
 
-https://<your-site>.github.io/?weeks=4
+`https://<your-site>.github.io/?weeks=4`
 
 ### QSW override
 
-https://<your-site>.github.io/?q=3&s=1&w=1
+`https://<your-site>.github.io/?q=3&s=1&w=1`
 
 When any of the `q`, `s`, or `w` parameters is present, the displayed Quarter,
 Sprint, and Week won't be calculated from the current date.
 
 ### Fancy + Links
 
-https://<your-site>.github.io/?fancy=neon\&links=Board|https%3A%2F%2Ftasks.com
+`https://<your-site>.github.io/?fancy=neon\&links=Board|https%3A%2F%2Ftasks.com`
 
 ## 🧪 Available themes
 


### PR DESCRIPTION
## Summary
- escape `<your-username>` placeholder in Live Example link
- wrap example URLs in inline code so `<your-site>` is visible

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_68592460060c8327a334b9c4c867e004